### PR TITLE
tfds.Split.TRAIN.subsplit() is deprecated

### DIFF
--- a/Chapter 5/horse_and_humans_transfer_learning.ipynb
+++ b/Chapter 5/horse_and_humans_transfer_learning.ipynb
@@ -71,7 +71,7 @@
         "import matplotlib.pyplot as plt\n",
         "\n",
         "SPLIT_WEIGHTS = (8, 1, 1)\n",
-        "splits = tfds.Split.TRAIN.subsplit(weighted=SPLIT_WEIGHTS)\n",
+        "splits = ('train[80%:]', 'train[80%:90%]', 'train[90%:]')\n",
         "(raw_train, raw_validation, raw_test), metadata = tfds.load(\n",
         "    'horses_or_humans', split=list(splits),\n",
         "    with_info=True, as_supervised=True)\n",


### PR DESCRIPTION
An error occurred while running the code Chapter 5/horse_and_humans_transfer_learning.ipynb.
`AttributeError: 'Split' object has no attribute 'subsplit'`

Since subsplit() is deprecated and to avoid a conflict afterwards, the variable `splits` is considered to be replaced to `('train[80%:]', 'train[80%:90%]', 'train[90%:]')` instead of `tfds.Split.TRAIN.subsplit(weighted=SPLIT_WEIGHTS)`.