### PR TITLE
Fixes typo and adds an input layer to the model explicitly in the imdb.py example.

### DIFF
--- a/Chapter 1/imdb.py
+++ b/Chapter 1/imdb.py
@@ -18,13 +18,13 @@ def load_data():
 
 def build_model():
 	model = models.Sequential()
-	#Input - Emedding Layer
+	#Input - Embedding Layer
 	# the model will take as input an integer matrix of size (batch, input_length)
 	# the model will output dimension (input_length, dim_embedding)
-    # the largest integer in the input should be no larger
-    # than n_words (vocabulary size).
-	model.add(layers.Embedding(n_words, 
-		dim_embedding, input_length=max_len))
+	# the largest integer in the input should be no larger
+	# than n_words (vocabulary size).
+	model.add(layers.InputLayer(input_shape=(max_len,)))
+	model.add(layers.Embedding(n_words, dim_embedding))
 
 	model.add(layers.Dropout(0.3))
 


### PR DESCRIPTION
The imdb.py example throws an error on my system with TensorFlow 2.15.0:

``` python
Traceback (most recent call last):
  File "/home/guest/devel/python/Tensorflow/first_model/tf_imdb_test.py", line 42, in <module>
    model = build_model()
  File "/home/guest/devel/python/Tensorflow/first_model/tf_imdb_test.py", line 31, in build_model
    model.add(tf.keras.layers.Embedding(n_words, dim_embedding, input_length = max_len))
  File "/home/guest/.local/lib/python3.9/site-packages/keras/src/layers/core/embedding.py", line 69, in __init__
    super().__init__(**kwargs)
  File "/home/guest/.local/lib/python3.9/site-packages/keras/src/layers/layer.py", line 264, in __init__
    raise ValueError(
ValueError: Unrecognized keyword arguments passed to Embedding: {'input_length': 200}
```